### PR TITLE
support alternative bash locations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 SRC_FILES := $(shell find src -name '*.ts')
 TEST_FILES := $(shell find test/tests -name '*.ts')
 BIN := ./node_modules/.bin


### PR DESCRIPTION
Using `/usr/bin/env bash` improves portability so the script will run correctly on systems where bash is not located in `/bin/bash`, e.g. NixOS